### PR TITLE
bug in keyname for NS-api call fixed

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -6,7 +6,7 @@ var keyname = "Ocp-Apim-Subscription-Key";
 
 init = {
     "method":"GET",
-    "headers":{keyname:key},
+    "headers":{"Ocp-Apim-Subscription-Key":key},
 };
 
 


### PR DESCRIPTION
Bug in line 9: 
init = {
    "method":"GET",
    "headers":{"Ocp-Apim-Subscription-Key":key},
};
for some reason using the variable keyname instead of "Ocp-Apim-Subscription-Key" did'nt work, fixed now